### PR TITLE
Added Characteristic.WaterLevel

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ class MiHumidifier {
     this.model = config.model || 'v1'
     this.showTemperature = config.showTemperature || false
     this.nameTemperature = config.nameTemperature || 'Temperature'
-    this.showWaterLevel = config.showWaterLevel || false
+    //this.showWaterLevel = config.showWaterLevel || false
 
     this.services = []
 
@@ -62,7 +62,7 @@ class MiHumidifier {
     // Current water level (remaining water level)
     // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier
     // zhimi.humidifier.v1 will always display 0% Water Level because it lacks a 'depth' property in miio
-    if (this.showWaterLevel) {
+    if (this.model = 'ca1') {
       this.service
         .getCharacteristic(Characteristic.WaterLevel)
         .on('get', this.getWaterLevel.bind(this))

--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ class MiHumidifier {
       .on('set', this.setTargetRelativeHumidity.bind(this))    
 
     // Current water level (remaining water level)
-    // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier, should work for zhimi.humidifier.v1
+    // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier
+    // zhimi.humidifier.v1 will always display 0% Water Level because it lacks a 'depth' property in miio
     this.service
       .getCharacteristic(Characteristic.WaterLevel)
       .on('get', this.getWaterLevel.bind(this))
@@ -67,7 +68,7 @@ class MiHumidifier {
     this.service
       .getCharacteristic(Characteristic.RotationSpeed)
       .setProps({
-        minValue: 0, // idle
+        minValue: 0, // auto - for zhimi.humidifier.ca1
         maxValue: 3, // high
         minStep: 1,
       })
@@ -208,7 +209,7 @@ class MiHumidifier {
   async getRotationSpeed(callback) {
     try {
       const modeToSpeed = {
-        'idle':   0,
+        'auto':   0,
         'silent': 1,
         'medium': 2,
         'high':   3,
@@ -236,7 +237,7 @@ class MiHumidifier {
       if (value > 0) {
         [ result ] = await this.device.call('set_mode', [speedToMode[value]])
       } else {
-        [ result ] = await this.device.call('set_power', ['off'])
+        [ result ] = await this.device.call('set_mode', ['auto'])
       }
 
       if (result !== 'ok')

--- a/index.js
+++ b/index.js
@@ -57,6 +57,12 @@ class MiHumidifier {
       .on('get', this.getTargetRelativeHumidity.bind(this))
       .on('set', this.setTargetRelativeHumidity.bind(this))    
 
+    // Current water level (remaining water level)
+    // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier, should work for zhimi.humidifier.v1
+    this.service
+      .getCharacteristic(Characteristic.WaterLevel)
+      .on('get', this.getWaterLevel.bind(this))
+    
     // Rotation speed
     this.service
       .getCharacteristic(Characteristic.RotationSpeed)
@@ -187,6 +193,17 @@ class MiHumidifier {
       callback(e)
     }
   }
+  
+  //Test: for accurate water level reading in HomeKit. callback(null, waterLevel / 0.12)??
+  async getWaterLevel(callback) {
+    try {
+      const [ waterLevel ] = await this.device.call('get_prop', ['depth'])
+      callback(null, waterLevel / 1.2)
+    } catch (e) {
+      this.log.error('getWaterLevel', e)
+      callback(e)
+    }
+  }  
 
   async getRotationSpeed(callback) {
     try {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,10 @@ class MiHumidifier {
     this.ip = config.ip
     this.token = config.token
     this.name = config.name || 'Humidifier'
+    this.model = config.model || 'v1'
     this.showTemperature = config.showTemperature || false
     this.nameTemperature = config.nameTemperature || 'Temperature'
+    this.showWaterLevel = config.showWaterLevel || false
 
     this.services = []
 
@@ -60,9 +62,11 @@ class MiHumidifier {
     // Current water level (remaining water level)
     // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier
     // zhimi.humidifier.v1 will always display 0% Water Level because it lacks a 'depth' property in miio
-    this.service
-      .getCharacteristic(Characteristic.WaterLevel)
-      .on('get', this.getWaterLevel.bind(this))
+    if (this.showWaterLevel) {
+      this.service
+        .getCharacteristic(Characteristic.WaterLevel)
+        .on('get', this.getWaterLevel.bind(this))
+    }
     
     // Rotation speed
     this.service
@@ -237,7 +241,11 @@ class MiHumidifier {
       if (value > 0) {
         [ result ] = await this.device.call('set_mode', [speedToMode[value]])
       } else {
-        [ result ] = await this.device.call('set_mode', ['auto'])
+        if (this.model = 'ca1') {
+          [ result ] = await this.device.call('set_mode', ['auto'])
+        } else {
+          [ result ] = await this.device.call('set_power', ['off'])
+        }
       }
 
       if (result !== 'ok')

--- a/index.js
+++ b/index.js
@@ -16,10 +16,8 @@ class MiHumidifier {
     this.token = config.token
     this.name = config.name || 'Humidifier'
     this.model = config.model || 'v1'
-    //this.version = config.model || 'v1'
     this.showTemperature = config.showTemperature || false
     this.nameTemperature = config.nameTemperature || 'Temperature'
-    //this.showWaterLevel = config.showWaterLevel || false
 
     this.services = []
 
@@ -62,8 +60,7 @@ class MiHumidifier {
 
     // Current water level (remaining water level)
     // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier
-    // zhimi.humidifier.v1 will always display 0% Water Level because it lacks a 'depth' property in miio
-    if (this.model = 'ca1') {//if (this.version = 'ca1') {
+    if (this.model = 'ca1') {
       this.service
         .getCharacteristic(Characteristic.WaterLevel)
         .on('get', this.getWaterLevel.bind(this))
@@ -200,7 +197,6 @@ class MiHumidifier {
     }
   }
   
-  //Test: for accurate water level reading in HomeKit. callback(null, waterLevel / 0.12)??
   async getWaterLevel(callback) {
     try {
       const [ waterLevel ] = await this.device.call('get_prop', ['depth'])
@@ -242,7 +238,7 @@ class MiHumidifier {
       if (value > 0) {
         [ result ] = await this.device.call('set_mode', [speedToMode[value]])
       } else {
-        if (this.model = 'ca1') {//if (this.version = 'ca1') {
+        if (this.model = 'ca1') {
           [ result ] = await this.device.call('set_mode', ['auto'])
         } else {
           [ result ] = await this.device.call('set_power', ['off'])

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class MiHumidifier {
     this.token = config.token
     this.name = config.name || 'Humidifier'
     this.model = config.model || 'v1'
+    //this.version = config.model || 'v1'
     this.showTemperature = config.showTemperature || false
     this.nameTemperature = config.nameTemperature || 'Temperature'
     //this.showWaterLevel = config.showWaterLevel || false
@@ -62,7 +63,7 @@ class MiHumidifier {
     // Current water level (remaining water level)
     // This characteristic works for zhimi.humidifier.ca1 SmartMi Evaporative Humidifier
     // zhimi.humidifier.v1 will always display 0% Water Level because it lacks a 'depth' property in miio
-    if (this.model = 'ca1') {
+    if (this.model = 'ca1') {//if (this.version = 'ca1') {
       this.service
         .getCharacteristic(Characteristic.WaterLevel)
         .on('get', this.getWaterLevel.bind(this))
@@ -241,7 +242,7 @@ class MiHumidifier {
       if (value > 0) {
         [ result ] = await this.device.call('set_mode', [speedToMode[value]])
       } else {
-        if (this.model = 'ca1') {
+        if (this.model = 'ca1') {//if (this.version = 'ca1') {
           [ result ] = await this.device.call('set_mode', ['auto'])
         } else {
           [ result ] = await this.device.call('set_power', ['off'])


### PR DESCRIPTION
Works with the new SmartMi Evaporative Humidifier (zhimi.humidifier.ca1)
Must test for equal water level reading in HomeKit (which matches reading from MiHome.app).

The original Xiaomi Mi UV Humidifier (zhimi.humidifier.v1) does not have a WaterLevel (depth) property.