### PR TITLE
Fix target humidity percentage in Home.app

### DIFF
--- a/src/devices/models/deerma-mjjsq.ts
+++ b/src/devices/models/deerma-mjjsq.ts
@@ -57,7 +57,10 @@ export function deermaMJJSQ(
         modes: [Gear.Low, Gear.Medium, Gear.High, Gear.Humidity],
       }),
       feat.humidity("Humidity_Value"),
-      feat.humidityThreshold("HumiSet_Value", "Set_HumiValue"),
+      feat.humidityThreshold("HumiSet_Value", "Set_HumiValue", {
+        min: 40,
+        max: 70,
+      }),
       feat.waterLevel("waterstatus", { toChar: (it) => it * 100 }),
 
       ...(options.ledBulb?.enabled

--- a/src/devices/models/zhimi-ca4.ts
+++ b/src/devices/models/zhimi-ca4.ts
@@ -84,7 +84,10 @@ export function zhimiCA4(
       feat.rotationSpeed("mode", "set_properties", {
         modes: [Mode.Low, Mode.Medium, Mode.High, Mode.Auto],
       }),
-      feat.humidityThreshold("target_humidity", "set_properties"),
+      feat.humidityThreshold("target_humidity", "set_properties", {
+        min: 30,
+        max: 80,
+      }),
       feat.waterLevel("water_level", {
         toChar: (it) => it / 1.2,
       }),

--- a/src/devices/models/zhimi-common.ts
+++ b/src/devices/models/zhimi-common.ts
@@ -24,7 +24,7 @@ export function zhimiCommon<PropsType extends CommonProps>(
     feat.targetState(),
     feat.currentState("power", { on: "on", off: "off" }),
     feat.active("power", "set_power", { on: "on", off: "off" }),
-    feat.humidityThreshold("limit_hum", "set_limit_hum"),
+    feat.humidityThreshold("limit_hum", "set_limit_hum", { min: 30, max: 80 }),
     feat.lockPhysicalControls("child_lock", "set_child_lock", {
       on: "on",
       off: "off",


### PR DESCRIPTION
Related to #57 
If minValue and maxValue are set for target humidity characteristic, Home.app doesn't limit values that could be selected, but instead maps new values to percents (0% - minValue, 100% - maxValue). This is not very intuitive, because percents in Home.app do not match with values in other apps.